### PR TITLE
Allow repository names based on path elements:

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -358,7 +358,16 @@ fn repo_prefix(
             if version == *"rawhide" {
                 return format!("{}-{}{}", rm.prefix, version, is_source_or_debug);
             } else {
-                let mut prefix = format!("{}{}-", rm.prefix, is_source_or_debug);
+                let mut prefix = format!(
+                    "{}{}-",
+                    match rm.prefix.contains('$') {
+                        // A '$' means that this contains a replacement group. Probably.
+                        true => pattern.replace(&path, rm.prefix.clone()).to_string(),
+                        _ => rm.prefix.clone(),
+                    },
+                    is_source_or_debug
+                );
+
                 for a in aliases {
                     if prefix == a.from {
                         prefix = a.to.clone();

--- a/src/scan_primary_mirror_test.rs
+++ b/src/scan_primary_mirror_test.rs
@@ -49,6 +49,10 @@ fn get_version_from_path_test() {
         "1030",
         get_version_from_path("top/development/1030/os".to_string())
     );
+    assert_eq!(
+        "9-stream",
+        get_version_from_path("SIGs/9-stream/infra/x86_64/infra-common/".to_string())
+    );
 }
 
 #[test]
@@ -118,7 +122,40 @@ fn repo_prefix_test() {
             regex: "^path/fedora/updates/testing/[\\.\\d]+/.*".to_string(),
             prefix: "fedora-updates-testing".to_string(),
         },
+        settings::RepositoryMapping {
+            regex:
+                "^SIGs/\\d+(?:-stream)?/(?P<signame>\\S+?)/(?P<arch>\\S+?)/(?P<sigrepo>\\S+?)/.*"
+                    .to_string(),
+            prefix: "centos-${signame}-sig-${sigrepo}".to_string(),
+        },
     ];
+    assert_eq!(
+        "centos-infra-sig-infra-common-9-stream",
+        repo_prefix(
+            "SIGs/9-stream/infra/x86_64/infra-common/repodata".to_string(),
+            "9-stream".to_string(),
+            &rms,
+            &aliases
+        )
+    );
+    assert_eq!(
+        "centos-infra-sig-infra-common-debug-9-stream",
+        repo_prefix(
+            "SIGs/9-stream/infra/x86_64/infra-common/debug/repodata".to_string(),
+            "9-stream".to_string(),
+            &rms,
+            &aliases
+        )
+    );
+    assert_eq!(
+        "centos-infra-sig-infra-common-source-9-stream",
+        repo_prefix(
+            "SIGs/9-stream/infra/source/infra-common/Packages".to_string(),
+            "9-stream".to_string(),
+            &rms,
+            &aliases
+        )
+    );
     assert_eq!(
         "",
         repo_prefix(


### PR DESCRIPTION
Regex:      ^SIGs/\\d+(?:-stream)?/(?P<signame>\\S+?)/(?P<arch>\\S+?)/(?P<sigrepo>\\S+?)/.*
Prefix:     centos-${signame}-sig-${sigrepo}
Path:       SIGs/9-stream/infra/x86_64/infra-common/repodata
Repository: centos-infra-sig-infra-common-9-stream